### PR TITLE
Adapt optimism portal

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
@@ -48,7 +48,8 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, Semver {
         uint256 _value,
         bytes memory _data
     ) internal override {
-        PORTAL.depositTransaction{ value: _value }(_to, _value, _gasLimit, false, _data);
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        PORTAL.depositTransaction(_to, _value, _gasLimit, false, _data);
     }
 
     /**

--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -420,7 +420,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         uint256 balanceBefore = nativeL2Token.balanceOf(address(this));
         nativeL2Token.transfer(_tx.target, _tx.value);
         uint256 balanceAfter = nativeL2Token.balanceOf(address(this));
-        bool success = balanceAfter - balanceBefore == _tx.value;
+        bool success = balanceBefore - balanceAfter == _tx.value;
 
         // Reset the l2Sender back to the default value.
         l2Sender = Constants.DEFAULT_L2_SENDER;

--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -418,7 +418,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
        
         //@p2perc20rollup send token to target
         uint256 balanceBefore = nativeL2Token.balanceOf(address(this));
-        nativeL2Token.transferFrom(l2Sender, _tx.target, _tx.value);
+        nativeL2Token.transfer(_tx.target, _tx.value);
         uint256 balanceAfter = nativeL2Token.balanceOf(address(this));
         bool success = balanceAfter - balanceBefore == _tx.value;
 

--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -479,7 +479,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // that the transaction can fit into the p2p network policy of 128kb even though deposit
         // transactions are not gossipped over the p2p network.
         // require(_data.length <= 120_000, "OptimismPortal: data too large");
-        require(_data.length == 0, "OptimismPortal: data should be zero"); //@p2perc20rollup no executions, so data should be empty
+        require(_data.length <= 1, "OptimismPortal: data should be zero"); //@p2perc20rollup no executions, so data should be empty
 
         // Transform the from-address to its alias if the caller is a contract.
         address from = msg.sender;

--- a/packages/contracts-bedrock/contracts/echidna/FuzzOptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/echidna/FuzzOptimismPortal.sol
@@ -6,6 +6,7 @@ import { AddressAliasHelper } from "../vendor/AddressAliasHelper.sol";
 import { SystemConfig } from "../L1/SystemConfig.sol";
 import { ResourceMetering } from "../L1/ResourceMetering.sol";
 import { Constants } from "../libraries/Constants.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 contract EchidnaFuzzOptimismPortal {
     OptimismPortal internal portal;
@@ -43,7 +44,10 @@ contract EchidnaFuzzOptimismPortal {
     ) public payable {
         failedToComplete = true;
         require(!_isCreation || _to == address(0), "EchidnaFuzzOptimismPortal: invalid test case.");
-        portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data);
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(portal), _mint);
+        portal.depositTransaction(_to, _value, _gasLimit, _isCreation, _data);
         failedToComplete = false;
     }
 

--- a/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
@@ -7,6 +7,7 @@ import { Vm } from "forge-std/Vm.sol";
 import "./CommonTest.t.sol";
 import { CrossDomainMessenger } from "../universal/CrossDomainMessenger.sol";
 import { ResourceMetering } from "../L1/ResourceMetering.sol";
+// import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 // Free function for setting the prevBaseFee param in the OptimismPortal.
 function setPrevBaseFee(
@@ -89,7 +90,10 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
     }
 
     function test_depositTransaction_benchmark() external {
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             NON_ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,
@@ -100,7 +104,10 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
 
     function test_depositTransaction_benchmark_1() external {
         setPrevBaseFee(vm, address(op), 1 gwei);
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             NON_ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,

--- a/packages/contracts-bedrock/contracts/test/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismPortal.t.sol
@@ -10,6 +10,7 @@ import { Types } from "../libraries/Types.sol";
 import { Hashing } from "../libraries/Hashing.sol";
 import { Proxy } from "../universal/Proxy.sol";
 import { ResourceMetering } from "../L1/ResourceMetering.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 contract OptimismPortal_Test is Portal_Initializer {
     event Paused(address);
@@ -103,12 +104,13 @@ contract OptimismPortal_Test is Portal_Initializer {
         assertEq(address(op).balance, 100);
     }
 
-    // Test: depositTransaction fails when contract creation has a non-zero destination address
-    function test_depositTransaction_contractCreation_reverts() external {
-        // contract creation must have a target of address(0)
-        vm.expectRevert("OptimismPortal: must send to address(0) when creating a contract");
-        op.depositTransaction(address(1), 1, 0, true, hex"");
-    }
+    // // Test: depositTransaction fails when contract creation has a non-zero destination address
+    // function test_depositTransaction_contractCreation_reverts() external {
+    //     // contract creation must have a target of address(0)
+    //     vm.expectRevert("OptimismPortal: must send to address(0) when creating a contract");
+    //     op.depositTransaction(address(1), 1, 0, true, hex"");
+    // }
+    //p2percrollup contracts do not exist in rollup
 
     /**
      * @notice Prevent deposits from being too large to have a sane upper bound
@@ -273,7 +275,10 @@ contract OptimismPortal_Test is Portal_Initializer {
             NON_ZERO_DATA
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             NON_ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,
@@ -296,7 +301,10 @@ contract OptimismPortal_Test is Portal_Initializer {
             NON_ZERO_DATA
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             NON_ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,
@@ -321,7 +329,10 @@ contract OptimismPortal_Test is Portal_Initializer {
             hex""
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,
@@ -344,7 +355,10 @@ contract OptimismPortal_Test is Portal_Initializer {
             NON_ZERO_DATA
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
+        //@p2perc20rollup remove {value:value} - transaction are made using erc20. portal is pulling the funds
+        //@p2perc20rollup we just need to approve
+        ERC20(0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf).approve(address(op), NON_ZERO_VALUE);
+        op.depositTransaction(
             ZERO_ADDRESS,
             ZERO_VALUE,
             NON_ZERO_GASLIMIT,


### PR DESCRIPTION
- remove ability to create smart contracts
- use erc20 transaction instead of value: msg.value
- adapt remaining contracts to updated portal